### PR TITLE
add GW rogan

### DIFF
--- a/configs/0-common/bird.d/10-common.conf
+++ b/configs/0-common/bird.d/10-common.conf
@@ -142,7 +142,7 @@ template bgp uplink_peers {
   # ignore routes for our own network
   import where !is_self_net();
   export filter only_freifunk;
-  route limit 10000;
+  route limit 10000;  # HIER kann man das Limit hoch drehen (z.B. route limit 10000000), wenn Berlin mehr als 10.000 Routen schickt!!
 };
 
 # template for prefered icvpn uplink gateway

--- a/configs/rogan/11-custom-sysctl.conf
+++ b/configs/rogan/11-custom-sysctl.conf
@@ -1,0 +1,16 @@
+#return path filter messes up our asymetric routes
+#so just disable it
+net.ipv4.conf.all.rp_filter=0
+net.ipv4.conf.default.rp_filter=0
+
+net.ipv4.conf.bat0.rp_filter=0
+net.ipv4.conf.br-fftr.rp_filter=0
+net.ipv4.conf.eth0.rp_filter=0
+net.ipv4.conf.fftr-mesh-vpn.rp_filter=0
+net.ipv4.conf.icvpn.rp_filter=0
+net.ipv4.conf.lo.rp_filter=0
+
+#increase conntrack-limits
+net.nf_conntrack_max=65536
+net.netfilter.nf_conntrack_buckets=16384
+

--- a/configs/rogan/bird.conf
+++ b/configs/rogan/bird.conf
@@ -1,0 +1,1 @@
+../0-common/bird.conf

--- a/configs/rogan/bird.d/.gitignore
+++ b/configs/rogan/bird.d/.gitignore
@@ -1,0 +1,2 @@
+icvpn.conf
+roa4.con

--- a/configs/rogan/bird.d/00-routerid.conf
+++ b/configs/rogan/bird.d/00-routerid.conf
@@ -1,0 +1,2 @@
+router id 10.207.0.221;
+define ownip = 10.172.0.12;

--- a/configs/rogan/bird.d/10-common.conf
+++ b/configs/rogan/bird.d/10-common.conf
@@ -1,0 +1,1 @@
+../../0-common/bird.d/10-common.conf

--- a/configs/rogan/bird.d/20-additional-nets.conf
+++ b/configs/rogan/bird.d/20-additional-nets.conf
@@ -1,0 +1,4 @@
+protocol static static_fftr_small { #traffic on marker 
+  route 10.172.32.0/19 via "br-fftr"; #traffic on marker
+  table ibgp; #traffic on marker
+}; #traffic on marker

--- a/configs/rogan/bird.d/30-peers.conf
+++ b/configs/rogan/bird.d/30-peers.conf
@@ -1,0 +1,18 @@
+### additional configuration  ###
+
+protocol bgp trier1 from locals {
+    neighbor 10.172.0.11 as 65022;
+}
+
+protocol bgp trier3 from locals {
+    neighbor 10.172.0.13 as 65022;
+}
+
+protocol bgp trier4 from locals {
+    neighbor 10.172.0.14 as 65022;
+}
+
+protocol bgp trier5 from locals {
+    neighbor 10.172.0.15 as 65022;
+}
+

--- a/configs/rogan/bird6.conf
+++ b/configs/rogan/bird6.conf
@@ -1,0 +1,1 @@
+../0-common/bird6.conf

--- a/configs/rogan/bird6.d/.gitignore
+++ b/configs/rogan/bird6.d/.gitignore
@@ -1,0 +1,2 @@
+icvpn.conf
+roa6.con

--- a/configs/rogan/bird6.d/00-routerid.conf
+++ b/configs/rogan/bird6.d/00-routerid.conf
@@ -1,0 +1,2 @@
+router id 10.207.0.221;
+define ownip = 2001:bf7:fc0f::12;

--- a/configs/rogan/bird6.d/10-common.conf
+++ b/configs/rogan/bird6.d/10-common.conf
@@ -1,0 +1,1 @@
+../../0-common/bird6.d/10-common.conf

--- a/configs/rogan/bird6.d/30-peers.conf
+++ b/configs/rogan/bird6.d/30-peers.conf
@@ -1,0 +1,18 @@
+### additional configuration  ###
+
+protocol bgp trier1 from locals {
+    neighbor 2001:bf7:fc0f::11 as 65022;
+}
+
+protocol bgp trier3 from locals {
+    neighbor 2001:bf7:fc0f::13 as 65022;
+}
+
+protocol bgp trier4 from locals {
+    neighbor 2001:bf7:fc0f::14 as 65022;
+}
+
+protocol bgp trier5 from locals {
+    neighbor 2001:bf7:fc0f::15 as 65022;
+}
+

--- a/configs/rogan/bird6.d/40-ra.conf
+++ b/configs/rogan/bird6.d/40-ra.conf
@@ -1,0 +1,18 @@
+
+#to router advertisments
+protocol radv {
+    interface "br-fftr" {
+	prefix 2001:bf7:fc0f::/64 {};
+        rdnss {
+            ns 2001:bf7:fc0f::12;
+        };  
+        #dnssl {
+        #    domain "bremen.freifunk.net";
+        #    lifetime mult 10; 
+        #};  
+    	max ra interval 20;
+    };  
+    trigger ::/0; # we send lifetime 0 if we have no internet uplink
+    export where net = ::/0;
+    table ibgp;
+};

--- a/configs/rogan/dhcpd.conf
+++ b/configs/rogan/dhcpd.conf
@@ -1,0 +1,14 @@
+authoritative;
+ddns-update-style none;
+option domain-name ".fftr";
+default-lease-time 600;
+max-lease-time 3600;
+subnet 10.172.0.0 netmask 255.255.0.0 {
+    # monitor: 80% 90% Y Freifunk Range
+    authoritative;
+    range 10.172.32.0 10.172.63.254;
+    option domain-name-servers 10.172.0.12, 10.172.0.15, 10.172.0.14, 10.172.0.13, 10.172.0.11;
+    option routers 10.172.0.12;
+}
+include "/etc/dhcp/static.conf";
+

--- a/configs/rogan/fastd.conf
+++ b/configs/rogan/fastd.conf
@@ -1,0 +1,14 @@
+log to syslog level debug;
+interface "fftr-mesh-vpn";
+method "salsa2012+umac"; 
+method "null";
+bind any:10000 interface "eth0";
+hide ip addresses yes;
+hide mac addresses yes;
+include "secret.conf";
+mtu 1406;
+include peers from "peers";
+on up "
+ ifup bat0
+ ifup $INTERFACE
+";

--- a/configs/rogan/interfaces
+++ b/configs/rogan/interfaces
@@ -1,0 +1,1 @@
+../0-common/interfaces

--- a/configs/rogan/interfaces.d/bat0.conf
+++ b/configs/rogan/interfaces.d/bat0.conf
@@ -1,0 +1,13 @@
+iface bat0 inet6 manual
+  pre-up batctl if add fftr-mesh-vpn
+  up ip link set $IFACE up
+  post-up brctl addif br-fftr $IFACE
+  post-up batctl it 10000
+  post-up batctl gw server
+  post-up /sbin/ip rule add from all fwmark 0x1 table 42
+
+  pre-down brctl delif br-fftr $IFACE || true
+  down ip link set $IFACE down
+  post-up start-stop-daemon -b --start --exec /usr/local/src/alfred-2014.4.0/alfred -- -i br-fftr;
+  post-up start-stop-daemon -b --start --exec /usr/local/src/alfred-2014.4.0/vis/batadv-vis -- -si bat0;
+

--- a/configs/rogan/interfaces.d/br-fftr.conf
+++ b/configs/rogan/interfaces.d/br-fftr.conf
@@ -1,0 +1,10 @@
+auto br-fftr
+  iface br-fftr inet6 static
+  bridge-ports none
+  address 2001:bf7:fc0f::12
+  netmask 64
+
+iface br-fftr inet static
+  address 10.172.0.12
+  netmask 255.255.0.0
+  allow-hotplug bat0

--- a/configs/rogan/interfaces.d/eth0.conf
+++ b/configs/rogan/interfaces.d/eth0.conf
@@ -1,0 +1,6 @@
+auto eth0
+iface eth0 inet static
+    address 46.231.178.61
+    netmask 255.255.254.0
+    gateway 46.231.178.1
+    # dns-nameservers 8.8.8.8 8.8.4.4

--- a/configs/rogan/interfaces.d/eth1.conf
+++ b/configs/rogan/interfaces.d/eth1.conf
@@ -1,0 +1,4 @@
+iface eth1 inet6 static
+        address 2a00:cd0:1:1107::14e
+        netmask 64
+        gateway  2a00:cd0:1:1107::1

--- a/configs/rogan/interfaces.d/fftr-mesh-vpn.conf
+++ b/configs/rogan/interfaces.d/fftr-mesh-vpn.conf
@@ -1,0 +1,2 @@
+iface fftr-mesh-vpn inet6 manual
+  hwaddress 26:61:96:60:18:dc

--- a/configs/rogan/interfaces.d/lo.conf
+++ b/configs/rogan/interfaces.d/lo.conf
@@ -1,0 +1,1 @@
+../../0-common/interfaces.d/lo.conf

--- a/configs/rogan/iptables
+++ b/configs/rogan/iptables
@@ -1,3 +1,2 @@
-NIC_PUBLIC=eth0
-NIC_PUBLIC=eth1
+NIC_PUBLIC=eth+
 

--- a/configs/rogan/iptables
+++ b/configs/rogan/iptables
@@ -1,0 +1,3 @@
+NIC_PUBLIC=eth0
+NIC_PUBLIC=eth1
+

--- a/configs/rogan/sbin.dhclient
+++ b/configs/rogan/sbin.dhclient
@@ -1,0 +1,1 @@
+../0-common/sbin.dhclient

--- a/configs/rogan/tinc-down
+++ b/configs/rogan/tinc-down
@@ -1,0 +1,4 @@
+#!/bin/sh
+/sbin/ip addr del dev $INTERFACE 10.207.0.221/16 broadcast 10.207.255.255
+/sbin/ip -6 addr del dev $INTERFACE fec0::a:cf:0:dd/96 preferred_lft 0
+/sbin/ip link set $INTERFACE down

--- a/configs/rogan/tinc-up
+++ b/configs/rogan/tinc-up
@@ -1,0 +1,4 @@
+#!/bin/sh
+/sbin/ip link set $INTERFACE up
+/sbin/ip addr add dev $INTERFACE 10.207.0.221/16 broadcast 10.207.255.255
+/sbin/ip -6 addr add dev $INTERFACE fec0::a:cf:0:dd/96 preferred_lft 0

--- a/configs/rogan/usr.sbin.dhcpd
+++ b/configs/rogan/usr.sbin.dhcpd
@@ -1,0 +1,1 @@
+../0-common/usr.sbin.dhcpd

--- a/configs/rogan/vnstat.conf
+++ b/configs/rogan/vnstat.conf
@@ -1,0 +1,129 @@
+# vnStat 1.11 config file
+##
+
+# default interface
+Interface "eth0"  # was ist mit eth1 ?
+
+# location of the database directory
+DatabaseDir "/var/lib/vnstat"
+
+# locale (LC_ALL) ("-" = use system locale)
+Locale "-"
+
+# on which day should months change
+MonthRotate 1
+
+# date output formats for -d, -m, -t and -w
+# see 'man date' for control codes
+DayFormat    "%d.%m.%y"
+MonthFormat  "%b '%y"
+TopFormat    "%a %d.%m.%y"
+
+# characters used for visuals
+RXCharacter       "%"
+TXCharacter       ":"
+RXHourCharacter   "r"
+TXHourCharacter   "t"
+
+# how units are prefixed when traffic is shown
+# 0 = IEC standard prefixes (KiB/MiB/GiB/TiB)
+# 1 = old style binary prefixes (KB/MB/GB/TB)
+UnitMode 0
+
+# output style
+# 0 = minimal & narrow, 1 = bar column visible
+# 2 = same as 1 except rate in summary and weekly
+# 3 = rate column visible
+OutputStyle 3
+
+# used rate unit (0 = bytes, 1 = bits)
+RateUnit 1
+
+# maximum bandwidth (Mbit) for all interfaces, 0 = disable feature
+# (unless interface specific limit is given)
+MaxBandwidth 1000
+
+# interface specific limits
+#  example 8Mbit limit for eth0 (remove # to activate):
+#MaxBWeth0 8
+
+# how many seconds should sampling for -tr take by default
+Sampletime 5
+
+# default query mode
+# 0 = normal, 1 = days, 2 = months, 3 = top10
+# 4 = dumpdb, 5 = short, 6 = weeks, 7 = hours
+QueryMode 0
+
+# filesystem disk space check (1 = enabled, 0 = disabled)
+CheckDiskSpace 1
+
+# database file locking (1 = enabled, 0 = disabled)
+UseFileLocking 1
+
+# how much the boot time can variate between updates (seconds)
+BootVariation 15
+
+# log days without traffic to daily list (1 = enabled, 0 = disabled)
+TrafficlessDays 1
+
+
+# vnstatd
+##
+
+# how often (in seconds) interface data is updated
+UpdateInterval 30
+
+# how often (in seconds) interface status changes are checked
+PollInterval 5
+
+# how often (in minutes) data is saved to file
+SaveInterval 5
+
+# how often (in minutes) data is saved when all interface are offline
+OfflineSaveInterval 30
+
+# force data save when interface status changes (1 = enabled, 0 = disabled)
+SaveOnStatusChange 1
+
+# enable / disable logging (0 = disabled, 1 = logfile, 2 = syslog)
+UseLogging 2
+
+# file used for logging if UseLogging is set to 1
+LogFile "/var/log/vnstat.log"
+
+# file used as daemon pid / lock file
+PidFile "/run/vnstat/vnstat.pid"
+
+
+# vnstati
+##
+
+# title timestamp format
+HeaderFormat "%d.%m.%y %H:%M"
+
+# show hours with rate (1 = enabled, 0 = disabled)
+HourlyRate 1
+
+# show rate in summary (1 = enabled, 0 = disabled)
+SummaryRate 1
+
+# layout of summary (1 = with monthly, 0 = without monthly)
+SummaryLayout 1
+
+# transparent background (1 = enabled, 0 = disabled)
+TransparentBg 0
+
+# image colors
+CBackground     "FFFFFF"
+CEdge           "AEAEAE"
+CHeader         "606060"
+CHeaderTitle    "FFFFFF"
+CHeaderDate     "FFFFFF"
+CText           "000000"
+CLine           "B0B0B0"
+CLineL          "-"
+CRx             "92CF00"
+CTx             "606060"
+CRxD            "-"
+CTxD            "-"

--- a/iptables.sh
+++ b/iptables.sh
@@ -46,8 +46,8 @@ echo "
 :notrack-helper-OUTPUT - [0:0]
 -A PREROUTING -i icvpn -j notrack-helper-PREROUTING
 -A PREROUTING -i br-fftr -j notrack-helper-PREROUTING
--A notrack-helper-PREROUTING -s 10.172.0.8/29 -j RETURN
--A notrack-helper-PREROUTING -d 10.172.0.8/29 -j RETURN
+-A notrack-helper-PREROUTING -s 10.172.0.0/27 -j RETURN
+-A notrack-helper-PREROUTING -d 10.172.0.0/27 -j RETURN
 -A notrack-helper-PREROUTING -s 10.207.0.216/29 -j RETURN
 -A notrack-helper-PREROUTING -d 10.207.0.216/29 -j RETURN
 -A notrack-helper-PREROUTING -s 10.207.0.93/32 -j RETURN
@@ -56,8 +56,8 @@ echo "
 
 -A OUTPUT -o icvpn -j notrack-helper-OUTPUT
 -A OUTPUT -o br-fftr -j notrack-helper-OUTPUT
--A notrack-helper-OUTPUT -s 10.172.0.8/29 -j RETURN
--A notrack-helper-OUTPUT -d 10.172.0.8/29 -j RETURN
+-A notrack-helper-OUTPUT -s 10.172.0.0/27 -j RETURN
+-A notrack-helper-OUTPUT -d 10.172.0.0/27 -j RETURN
 -A notrack-helper-OUTPUT -s 10.207.0.216/29 -j RETURN
 -A notrack-helper-OUTPUT -d 10.207.0.216/29 -j RETURN
 -A notrack-helper-OUTPUT -s 10.207.0.93/32 -j RETURN


### PR DESCRIPTION
Bitte mal drüber schauen. iptables.sh mit nottrack-helper fehlt noch. Wer vergibt hier die IPs 10.207.0.x/32  ?
Wir haben 2 Interface eth0 und eth1. Das hatten wir noch nicht. Z.B.
configs/rogan/vnstat.conf : da fehlt daher noch eth1
configs/rogan/iptables : macht man das dort so oder kommen die beiden ifaces in eine Zeile mit leerzeichen getrennt oder wie?